### PR TITLE
Add resolution capping utilities for StyleGAN models

### DIFF
--- a/cap_resolution_utils.py
+++ b/cap_resolution_utils.py
@@ -1,0 +1,219 @@
+"""
+Utility functions for capping the resolution of StyleGAN2 and StyleGAN3 generators.
+"""
+
+import re
+import copy
+import torch
+from torch_utils import misc
+
+def create_capped_stylegan3_generator(G_original, target_resolution):
+    """
+    Create a new StyleGAN3 generator with a capped resolution based on the original generator.
+    
+    Args:
+        G_original: The original StyleGAN3 generator model
+        target_resolution: The target resolution to cap at (e.g., 512)
+        
+    Returns:
+        A new generator with the same weights as the original but capped at the target resolution
+    """
+    # Ensure target resolution is a power of 2
+    assert (target_resolution & (target_resolution - 1) == 0) and target_resolution > 0, \
+        f"Target resolution must be a power of 2, got {target_resolution}"
+    
+    # Ensure target resolution is not larger than the original
+    assert target_resolution <= G_original.img_resolution, \
+        f"Target resolution ({target_resolution}) cannot be larger than original ({G_original.img_resolution})"
+    
+    # Create a copy of the original generator's kwargs
+    kwargs = copy.deepcopy(G_original.init_kwargs)
+    
+    # Update the resolution in the kwargs
+    kwargs['img_resolution'] = target_resolution
+    
+    # Adjust synthesis kwargs if needed
+    if 'synthesis_kwargs' in kwargs:
+        kwargs['synthesis_kwargs']['img_resolution'] = target_resolution
+    
+    # Create a new generator with the updated kwargs
+    G_capped = type(G_original)(**kwargs).eval().requires_grad_(False)
+    
+    # Copy the mapping network weights (these are independent of resolution)
+    misc.copy_params_and_buffers(G_original.mapping, G_capped.mapping, require_all=True)
+    
+    # Copy the synthesis network weights up to the target resolution
+    # First, get all named parameters and buffers from both networks
+    orig_params = dict(G_original.synthesis.named_parameters())
+    orig_buffers = dict(G_original.synthesis.named_buffers())
+    capped_params = dict(G_capped.synthesis.named_parameters())
+    capped_buffers = dict(G_capped.synthesis.named_buffers())
+    
+    # Copy input layer parameters (these are always needed)
+    for name in capped_params:
+        if name.startswith('input.'):
+            if name in orig_params:
+                capped_params[name].copy_(orig_params[name])
+    
+    for name in capped_buffers:
+        if name.startswith('input.'):
+            if name in orig_buffers:
+                capped_buffers[name].copy_(orig_buffers[name])
+    
+    # Copy synthesis layer parameters up to the target resolution
+    for name in list(capped_params.keys()):
+        # Extract resolution from layer name (e.g., 'L2_32_512' -> 32)
+        match = re.match(r'L\d+_(\d+)_\d+', name.split('.')[0])
+        if match:
+            layer_res = int(match.group(1))
+            # Only copy if the layer resolution is less than or equal to target
+            if layer_res <= target_resolution:
+                if name in orig_params:
+                    capped_params[name].copy_(orig_params[name])
+    
+    for name in list(capped_buffers.keys()):
+        match = re.match(r'L\d+_(\d+)_\d+', name.split('.')[0])
+        if match:
+            layer_res = int(match.group(1))
+            if layer_res <= target_resolution:
+                if name in orig_buffers:
+                    capped_buffers[name].copy_(orig_buffers[name])
+    
+    return G_capped
+
+def create_capped_stylegan2_generator(G_original, target_resolution):
+    """
+    Create a new StyleGAN2 generator with a capped resolution based on the original generator.
+    This works specifically with the StyleGAN2 implementation from the StyleGAN3 repository.
+    
+    Args:
+        G_original: The original StyleGAN2 generator model
+        target_resolution: The target resolution to cap at (e.g., 512)
+        
+    Returns:
+        A new generator with the same weights as the original but capped at the target resolution
+    """
+    # Ensure target resolution is a power of 2
+    assert (target_resolution & (target_resolution - 1) == 0) and target_resolution > 0, \
+        f"Target resolution must be a power of 2, got {target_resolution}"
+    
+    # Ensure target resolution is not larger than the original
+    assert target_resolution <= G_original.img_resolution, \
+        f"Target resolution ({target_resolution}) cannot be larger than original ({G_original.img_resolution})"
+    
+    # Create a new generator with the same architecture but different resolution
+    # First, get the original kwargs
+    synthesis_kwargs = copy.deepcopy(G_original.synthesis.init_kwargs)
+    mapping_kwargs = copy.deepcopy(G_original.mapping.init_kwargs)
+    
+    # Update the resolution in the synthesis kwargs
+    synthesis_kwargs['img_resolution'] = target_resolution
+    
+    # Get the original block resolutions
+    orig_block_resolutions = G_original.synthesis.block_resolutions
+    
+    # Filter block resolutions to only include those up to the target resolution
+    new_block_resolutions = [res for res in orig_block_resolutions if res <= target_resolution]
+    synthesis_kwargs['block_resolutions'] = new_block_resolutions
+    
+    # Create a new generator with the updated kwargs
+    from training.networks_stylegan2 import Generator
+    G_capped = Generator(
+        z_dim=G_original.z_dim,
+        c_dim=G_original.c_dim,
+        w_dim=G_original.w_dim,
+        img_resolution=target_resolution,
+        img_channels=G_original.img_channels,
+        mapping_kwargs=mapping_kwargs,
+        synthesis_kwargs=synthesis_kwargs
+    ).eval().requires_grad_(False)
+    
+    # Copy the mapping network weights (these are independent of resolution)
+    misc.copy_params_and_buffers(G_original.mapping, G_capped.mapping, require_all=True)
+    
+    # Copy the synthesis network weights up to the target resolution
+    # For each block in the capped generator, copy the corresponding weights from the original
+    for res in new_block_resolutions:
+        block_name = f'b{res}'
+        if hasattr(G_original.synthesis, block_name) and hasattr(G_capped.synthesis, block_name):
+            orig_block = getattr(G_original.synthesis, block_name)
+            capped_block = getattr(G_capped.synthesis, block_name)
+            
+            # Copy all parameters and buffers for this block
+            misc.copy_params_and_buffers(orig_block, capped_block, require_all=True)
+    
+    return G_capped
+
+def load_and_cap_generator(network_pkl, target_resolution, is_stylegan3=True):
+    """
+    Load a pre-trained StyleGAN model and create a generator with a capped resolution.
+    
+    Args:
+        network_pkl: Path or URL to the .pkl file containing the StyleGAN model
+        target_resolution: The target resolution to cap at (e.g., 512)
+        is_stylegan3: Whether the model is StyleGAN3 (True) or StyleGAN2 (False)
+        
+    Returns:
+        A tuple containing (original_generator, capped_generator)
+    """
+    import dnnlib
+    import legacy
+    
+    # Set device
+    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+    
+    # Load the network
+    with dnnlib.util.open_url(network_pkl) as f:
+        network_data = legacy.load_network_pkl(f)
+        G_original = network_data['G_ema'].to(device)
+    
+    # Create a capped generator
+    if is_stylegan3:
+        G_capped = create_capped_stylegan3_generator(G_original, target_resolution)
+    else:
+        G_capped = create_capped_stylegan2_generator(G_original, target_resolution)
+    
+    return G_original, G_capped
+
+def generate_images(G, z, c=None, truncation_psi=0.7, noise_mode='const'):
+    """
+    Generate images using a StyleGAN generator.
+    
+    Args:
+        G: The generator model
+        z: The latent vectors (batch_size x z_dim)
+        c: The class labels (batch_size x c_dim), or None for unconditional models
+        truncation_psi: Truncation psi value (lower = more average/less variation)
+        noise_mode: Noise mode ('const', 'random', 'none')
+        
+    Returns:
+        Generated images as a torch tensor (batch_size x 3 x resolution x resolution)
+    """
+    if c is None:
+        c = torch.zeros([z.shape[0], G.c_dim], device=z.device)
+    
+    # Generate images
+    img = G(z, c, truncation_psi=truncation_psi, noise_mode=noise_mode)
+    
+    return img
+
+def save_generator(G, output_pkl, network_data=None):
+    """
+    Save a generator model to a .pkl file.
+    
+    Args:
+        G: The generator model to save
+        output_pkl: Path to the output .pkl file
+        network_data: Optional dictionary containing additional network data
+        
+    Returns:
+        None
+    """
+    if network_data is None:
+        network_data = {'G_ema': G}
+    else:
+        network_data = {k: v for k, v in network_data.items()}
+        network_data['G_ema'] = G
+    
+    with open(output_pkl, 'wb') as f:
+        torch.save(network_data, f)

--- a/cap_stylegan2_resolution.py
+++ b/cap_stylegan2_resolution.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""
+Script to create a StyleGAN2 generator with a capped resolution.
+This works with the StyleGAN2 implementation from the StyleGAN3 repository.
+"""
+
+import re
+import copy
+import torch
+import dnnlib
+import legacy
+from torch_utils import misc
+
+def create_capped_stylegan2_generator(G_original, target_resolution):
+    """
+    Create a new StyleGAN2 generator with a capped resolution based on the original generator.
+    This works specifically with the StyleGAN2 implementation from the StyleGAN3 repository.
+    
+    Args:
+        G_original: The original StyleGAN2 generator model
+        target_resolution: The target resolution to cap at (e.g., 512)
+        
+    Returns:
+        A new generator with the same weights as the original but capped at the target resolution
+    """
+    # Ensure target resolution is a power of 2
+    assert (target_resolution & (target_resolution - 1) == 0) and target_resolution > 0, \
+        f"Target resolution must be a power of 2, got {target_resolution}"
+    
+    # Ensure target resolution is not larger than the original
+    assert target_resolution <= G_original.img_resolution, \
+        f"Target resolution ({target_resolution}) cannot be larger than original ({G_original.img_resolution})"
+    
+    # Calculate the number of blocks needed for the target resolution
+    # StyleGAN2 starts at 4x4 and doubles resolution with each block
+    num_blocks = (target_resolution // 4).bit_length()
+    
+    # Create a copy of the original generator
+    G_capped = copy.deepcopy(G_original)
+    
+    # Modify the synthesis network to cap at the target resolution
+    G_capped.synthesis.img_resolution = target_resolution
+    G_capped.img_resolution = target_resolution
+    
+    # Get the original and new synthesis blocks
+    orig_blocks = G_original.synthesis.block_resolutions
+    target_blocks = [res for res in orig_blocks if res <= target_resolution]
+    
+    # Update the block_resolutions attribute
+    G_capped.synthesis.block_resolutions = target_blocks
+    
+    # Remove blocks that exceed the target resolution
+    for res in orig_blocks:
+        if res > target_resolution:
+            block_name = f'b{res}'
+            if hasattr(G_capped.synthesis, block_name):
+                delattr(G_capped.synthesis, block_name)
+    
+    # Update the output layer to match the new resolution
+    if hasattr(G_capped.synthesis, 'img_output'):
+        delattr(G_capped.synthesis, 'img_output')
+        
+    # Create a new output layer for the target resolution
+    output_block_name = f'b{target_resolution}'
+    if hasattr(G_capped.synthesis, output_block_name):
+        output_block = getattr(G_capped.synthesis, output_block_name)
+        G_capped.synthesis.img_output = output_block.torgb
+    
+    # Update the num_ws attribute if needed
+    if hasattr(G_capped.synthesis, 'num_ws'):
+        # Calculate the new num_ws based on the number of remaining blocks
+        G_capped.synthesis.num_ws = G_capped.mapping.num_ws = 2 * len(target_blocks)
+    
+    return G_capped
+
+def main():
+    """Example usage of the capped generator function."""
+    import argparse
+    import os
+    import numpy as np
+    import PIL.Image
+    
+    parser = argparse.ArgumentParser(description="Create a StyleGAN2 generator with capped resolution")
+    parser.add_argument("--network", type=str, help="Path to the .pkl file containing the StyleGAN2 model")
+    parser.add_argument("--resolution", type=int, default=512, help="Target resolution to cap at (default: 512)")
+    parser.add_argument("--output", type=str, default="capped_stylegan2.pkl", help="Output .pkl file path")
+    parser.add_argument("--seed", type=int, default=0, help="Random seed for image generation")
+    parser.add_argument("--outdir", type=str, default="out", help="Directory to save output images")
+    args = parser.parse_args()
+    
+    # Set device
+    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+    print(f"Using device: {device}")
+    
+    # Load the network
+    print(f"Loading network from {args.network}...")
+    with dnnlib.util.open_url(args.network) as f:
+        network_data = legacy.load_network_pkl(f)
+        G_original = network_data['G_ema'].to(device)
+    
+    print(f"Original generator resolution: {G_original.img_resolution}")
+    
+    # Create a capped generator
+    print(f"Creating capped generator with resolution {args.resolution}...")
+    G_capped = create_capped_stylegan2_generator(G_original, args.resolution)
+    
+    print(f"Capped generator resolution: {G_capped.img_resolution}")
+    
+    # Generate a sample image with both generators
+    os.makedirs(args.outdir, exist_ok=True)
+    
+    # Create a random latent vector
+    z = torch.from_numpy(np.random.RandomState(args.seed).randn(1, G_original.z_dim)).to(device)
+    
+    # Create a label tensor (zeros for unconditional models)
+    c = torch.zeros([1, G_original.c_dim], device=device)
+    
+    # Generate images
+    print("Generating images...")
+    
+    # Original generator
+    img_original = G_original(z, c, truncation_psi=0.7, noise_mode='const')
+    img_original = (img_original.permute(0, 2, 3, 1) * 127.5 + 128).clamp(0, 255).to(torch.uint8)
+    
+    # Capped generator
+    img_capped = G_capped(z, c, truncation_psi=0.7, noise_mode='const')
+    img_capped = (img_capped.permute(0, 2, 3, 1) * 127.5 + 128).clamp(0, 255).to(torch.uint8)
+    
+    # Save images
+    PIL.Image.fromarray(img_original[0].cpu().numpy(), 'RGB').save(f"{args.outdir}/original_{G_original.img_resolution}.png")
+    PIL.Image.fromarray(img_capped[0].cpu().numpy(), 'RGB').save(f"{args.outdir}/capped_{args.resolution}.png")
+    
+    print(f"Images saved to {args.outdir}")
+    
+    # Save the capped generator
+    print(f"Saving capped generator to {args.output}...")
+    capped_network_data = {k: v for k, v in network_data.items()}
+    capped_network_data['G_ema'] = G_capped
+    
+    with open(args.output, 'wb') as f:
+        torch.save(capped_network_data, f)
+    
+    print(f"Capped generator saved to {args.output}")
+
+if __name__ == "__main__":
+    main()

--- a/resolution_capping_demo.ipynb
+++ b/resolution_capping_demo.ipynb
@@ -1,0 +1,374 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# StyleGAN Resolution Capping Demo\n",
+    "\n",
+    "This notebook demonstrates how to load a pre-trained StyleGAN2 or StyleGAN3 model and create a new generator with a capped resolution (e.g., maximum 512px)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "source": [
+    "import os\n",
+    "import torch\n",
+    "import numpy as np\n",
+    "import PIL.Image\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "# Make sure we're in the StyleGAN3 directory\n",
+    "os.chdir('/workspace/stylegan3')\n",
+    "\n",
+    "import dnnlib\n",
+    "import legacy\n",
+    "from cap_resolution_utils import (\n",
+    "    load_and_cap_generator,\n",
+    "    generate_images,\n",
+    "    save_generator\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Configuration"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "source": [
+    "# Choose a pre-trained model\n",
+    "# StyleGAN3 model\n",
+    "stylegan3_pkl = \"https://api.ngc.nvidia.com/v2/models/nvidia/research/stylegan3/versions/1/files/stylegan3-r-ffhq-1024x1024.pkl\"\n",
+    "\n",
+    "# StyleGAN2 model\n",
+    "stylegan2_pkl = \"https://api.ngc.nvidia.com/v2/models/nvidia/research/stylegan2/versions/1/files/stylegan2-ffhq-1024x1024.pkl\"\n",
+    "\n",
+    "# Set the target resolution\n",
+    "target_resolution = 512\n",
+    "\n",
+    "# Set device\n",
+    "device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')\n",
+    "print(f\"Using device: {device}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## StyleGAN3 Example"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "source": [
+    "# Load and cap a StyleGAN3 model\n",
+    "print(f\"Loading and capping StyleGAN3 model...\")\n",
+    "G3_original, G3_capped = load_and_cap_generator(\n",
+    "    stylegan3_pkl, \n",
+    "    target_resolution, \n",
+    "    is_stylegan3=True\n",
+    ")\n",
+    "\n",
+    "print(f\"Original StyleGAN3 resolution: {G3_original.img_resolution}\")\n",
+    "print(f\"Capped StyleGAN3 resolution: {G3_capped.img_resolution}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "source": [
+    "# Generate images with both generators\n",
+    "seed = 42\n",
+    "z = torch.from_numpy(np.random.RandomState(seed).randn(1, G3_original.z_dim)).to(device)\n",
+    "\n",
+    "# Generate images\n",
+    "img3_original = generate_images(G3_original, z, truncation_psi=0.7)\n",
+    "img3_capped = generate_images(G3_capped, z, truncation_psi=0.7)\n",
+    "\n",
+    "# Convert to displayable format\n",
+    "img3_original_display = (img3_original.permute(0, 2, 3, 1) * 127.5 + 128).clamp(0, 255).to(torch.uint8)\n",
+    "img3_capped_display = (img3_capped.permute(0, 2, 3, 1) * 127.5 + 128).clamp(0, 255).to(torch.uint8)\n",
+    "\n",
+    "# Display the images side by side\n",
+    "fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(20, 10))\n",
+    "\n",
+    "ax1.imshow(img3_original_display[0].cpu().numpy())\n",
+    "ax1.set_title(f\"StyleGAN3 Original ({G3_original.img_resolution}x{G3_original.img_resolution})\")\n",
+    "ax1.axis('off')\n",
+    "\n",
+    "ax2.imshow(img3_capped_display[0].cpu().numpy())\n",
+    "ax2.set_title(f\"StyleGAN3 Capped ({G3_capped.img_resolution}x{G3_capped.img_resolution})\")\n",
+    "ax2.axis('off')\n",
+    "\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## StyleGAN2 Example"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "source": [
+    "# Load and cap a StyleGAN2 model\n",
+    "print(f\"Loading and capping StyleGAN2 model...\")\n",
+    "G2_original, G2_capped = load_and_cap_generator(\n",
+    "    stylegan2_pkl, \n",
+    "    target_resolution, \n",
+    "    is_stylegan3=False\n",
+    ")\n",
+    "\n",
+    "print(f\"Original StyleGAN2 resolution: {G2_original.img_resolution}\")\n",
+    "print(f\"Capped StyleGAN2 resolution: {G2_capped.img_resolution}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "source": [
+    "# Generate images with both generators\n",
+    "seed = 42\n",
+    "z = torch.from_numpy(np.random.RandomState(seed).randn(1, G2_original.z_dim)).to(device)\n",
+    "\n",
+    "# Generate images\n",
+    "img2_original = generate_images(G2_original, z, truncation_psi=0.7)\n",
+    "img2_capped = generate_images(G2_capped, z, truncation_psi=0.7)\n",
+    "\n",
+    "# Convert to displayable format\n",
+    "img2_original_display = (img2_original.permute(0, 2, 3, 1) * 127.5 + 128).clamp(0, 255).to(torch.uint8)\n",
+    "img2_capped_display = (img2_capped.permute(0, 2, 3, 1) * 127.5 + 128).clamp(0, 255).to(torch.uint8)\n",
+    "\n",
+    "# Display the images side by side\n",
+    "fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(20, 10))\n",
+    "\n",
+    "ax1.imshow(img2_original_display[0].cpu().numpy())\n",
+    "ax1.set_title(f\"StyleGAN2 Original ({G2_original.img_resolution}x{G2_original.img_resolution})\")\n",
+    "ax1.axis('off')\n",
+    "\n",
+    "ax2.imshow(img2_capped_display[0].cpu().numpy())\n",
+    "ax2.set_title(f\"StyleGAN2 Capped ({G2_capped.img_resolution}x{G2_capped.img_resolution})\")\n",
+    "ax2.axis('off')\n",
+    "\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Try Different Seeds"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "source": [
+    "def generate_and_display(generator_type, seed, truncation_psi=0.7):\n",
+    "    \"\"\"Generate and display images from both original and capped generators.\"\"\"\n",
+    "    if generator_type.lower() == 'stylegan3':\n",
+    "        G_original, G_capped = G3_original, G3_capped\n",
+    "        title = \"StyleGAN3\"\n",
+    "    else:\n",
+    "        G_original, G_capped = G2_original, G2_capped\n",
+    "        title = \"StyleGAN2\"\n",
+    "    \n",
+    "    # Create a random latent vector\n",
+    "    z = torch.from_numpy(np.random.RandomState(seed).randn(1, G_original.z_dim)).to(device)\n",
+    "    \n",
+    "    # Generate images\n",
+    "    img_original = generate_images(G_original, z, truncation_psi=truncation_psi)\n",
+    "    img_capped = generate_images(G_capped, z, truncation_psi=truncation_psi)\n",
+    "    \n",
+    "    # Convert to displayable format\n",
+    "    img_original_display = (img_original.permute(0, 2, 3, 1) * 127.5 + 128).clamp(0, 255).to(torch.uint8)\n",
+    "    img_capped_display = (img_capped.permute(0, 2, 3, 1) * 127.5 + 128).clamp(0, 255).to(torch.uint8)\n",
+    "    \n",
+    "    # Display the images side by side\n",
+    "    fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(20, 10))\n",
+    "    \n",
+    "    ax1.imshow(img_original_display[0].cpu().numpy())\n",
+    "    ax1.set_title(f\"{title} Original ({G_original.img_resolution}x{G_original.img_resolution})\")\n",
+    "    ax1.axis('off')\n",
+    "    \n",
+    "    ax2.imshow(img_capped_display[0].cpu().numpy())\n",
+    "    ax2.set_title(f\"{title} Capped ({G_capped.img_resolution}x{G_capped.img_resolution})\")\n",
+    "    ax2.axis('off')\n",
+    "    \n",
+    "    plt.tight_layout()\n",
+    "    plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "source": [
+    "# Try with different seeds for StyleGAN3\n",
+    "generate_and_display('stylegan3', seed=100)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "source": [
+    "# Try with different seeds for StyleGAN2\n",
+    "generate_and_display('stylegan2', seed=100)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "source": [
+    "# Try with another seed and different truncation\n",
+    "generate_and_display('stylegan3', seed=200, truncation_psi=0.5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Save the Capped Generators"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "source": [
+    "# Save the capped StyleGAN3 generator\n",
+    "stylegan3_output_pkl = f\"stylegan3_capped_{target_resolution}.pkl\"\n",
+    "print(f\"Saving capped StyleGAN3 generator to {stylegan3_output_pkl}...\")\n",
+    "\n",
+    "# Load the original network data to preserve other components\n",
+    "with dnnlib.util.open_url(stylegan3_pkl) as f:\n",
+    "    stylegan3_network_data = legacy.load_network_pkl(f)\n",
+    "\n",
+    "# Save the generator\n",
+    "save_generator(G3_capped, stylegan3_output_pkl, stylegan3_network_data)\n",
+    "print(f\"Capped StyleGAN3 generator saved to {stylegan3_output_pkl}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "source": [
+    "# Save the capped StyleGAN2 generator\n",
+    "stylegan2_output_pkl = f\"stylegan2_capped_{target_resolution}.pkl\"\n",
+    "print(f\"Saving capped StyleGAN2 generator to {stylegan2_output_pkl}...\")\n",
+    "\n",
+    "# Load the original network data to preserve other components\n",
+    "with dnnlib.util.open_url(stylegan2_pkl) as f:\n",
+    "    stylegan2_network_data = legacy.load_network_pkl(f)\n",
+    "\n",
+    "# Save the generator\n",
+    "save_generator(G2_capped, stylegan2_output_pkl, stylegan2_network_data)\n",
+    "print(f\"Capped StyleGAN2 generator saved to {stylegan2_output_pkl}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Verify the Saved Models"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "source": [
+    "# Load the saved capped StyleGAN3 generator\n",
+    "print(f\"Loading capped StyleGAN3 generator from {stylegan3_output_pkl}...\")\n",
+    "with open(stylegan3_output_pkl, 'rb') as f:\n",
+    "    loaded_network_data = torch.load(f)\n",
+    "    G3_loaded = loaded_network_data['G_ema'].to(device)\n",
+    "\n",
+    "print(f\"Loaded StyleGAN3 generator resolution: {G3_loaded.img_resolution}\")\n",
+    "\n",
+    "# Generate an image with the loaded generator\n",
+    "seed = 300\n",
+    "z = torch.from_numpy(np.random.RandomState(seed).randn(1, G3_loaded.z_dim)).to(device)\n",
+    "\n",
+    "img3_loaded = generate_images(G3_loaded, z, truncation_psi=0.7)\n",
+    "img3_loaded_display = (img3_loaded.permute(0, 2, 3, 1) * 127.5 + 128).clamp(0, 255).to(torch.uint8)\n",
+    "\n",
+    "plt.figure(figsize=(10, 10))\n",
+    "plt.imshow(img3_loaded_display[0].cpu().numpy())\n",
+    "plt.title(f\"Image from loaded capped StyleGAN3 ({G3_loaded.img_resolution}x{G3_loaded.img_resolution})\")\n",
+    "plt.axis('off')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "source": [
+    "# Load the saved capped StyleGAN2 generator\n",
+    "print(f\"Loading capped StyleGAN2 generator from {stylegan2_output_pkl}...\")\n",
+    "with open(stylegan2_output_pkl, 'rb') as f:\n",
+    "    loaded_network_data = torch.load(f)\n",
+    "    G2_loaded = loaded_network_data['G_ema'].to(device)\n",
+    "\n",
+    "print(f\"Loaded StyleGAN2 generator resolution: {G2_loaded.img_resolution}\")\n",
+    "\n",
+    "# Generate an image with the loaded generator\n",
+    "seed = 300\n",
+    "z = torch.from_numpy(np.random.RandomState(seed).randn(1, G2_loaded.z_dim)).to(device)\n",
+    "\n",
+    "img2_loaded = generate_images(G2_loaded, z, truncation_psi=0.7)\n",
+    "img2_loaded_display = (img2_loaded.permute(0, 2, 3, 1) * 127.5 + 128).clamp(0, 255).to(torch.uint8)\n",
+    "\n",
+    "plt.figure(figsize=(10, 10))\n",
+    "plt.imshow(img2_loaded_display[0].cpu().numpy())\n",
+    "plt.title(f\"Image from loaded capped StyleGAN2 ({G2_loaded.img_resolution}x{G2_loaded.img_resolution})\")\n",
+    "plt.axis('off')\n",
+    "plt.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/stylegan2_capped_example.py
+++ b/stylegan2_capped_example.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""
+Example script demonstrating how to load a pre-trained StyleGAN2 model from the StyleGAN3 repository,
+create a generator with a capped resolution, and generate images with it.
+"""
+
+import os
+import torch
+import numpy as np
+import PIL.Image
+import dnnlib
+import legacy
+from cap_stylegan2_resolution import create_capped_stylegan2_generator
+
+def main():
+    # Configuration
+    network_pkl = "https://api.ngc.nvidia.com/v2/models/nvidia/research/stylegan2/versions/1/files/stylegan2-ffhq-1024x1024.pkl"  # Pre-trained model URL
+    target_resolution = 512  # Target resolution to cap at
+    output_dir = "stylegan2_capped_output"  # Directory to save output images
+    num_samples = 3  # Number of sample images to generate
+    seeds = [100, 200, 300]  # Random seeds for reproducibility
+    
+    # Create output directory
+    os.makedirs(output_dir, exist_ok=True)
+    
+    # Set device
+    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+    print(f"Using device: {device}")
+    
+    # Load the pre-trained model
+    print(f"Loading network from {network_pkl}...")
+    with dnnlib.util.open_url(network_pkl) as f:
+        network_data = legacy.load_network_pkl(f)
+        G_original = network_data['G_ema'].to(device)
+    
+    print(f"Original generator resolution: {G_original.img_resolution}")
+    print(f"Original generator type: {type(G_original).__name__}")
+    
+    # Print the synthesis network structure to understand the block naming
+    print("\nOriginal synthesis network structure:")
+    for name, _ in G_original.synthesis.named_parameters():
+        if 'weight' in name and 'torgb' not in name:
+            print(f"  {name}")
+    
+    # Create a capped generator
+    print(f"\nCreating capped generator with resolution {target_resolution}...")
+    G_capped = create_capped_stylegan2_generator(G_original, target_resolution)
+    
+    print(f"Capped generator resolution: {G_capped.img_resolution}")
+    
+    # Print the capped synthesis network structure
+    print("\nCapped synthesis network structure:")
+    for name, _ in G_capped.synthesis.named_parameters():
+        if 'weight' in name and 'torgb' not in name:
+            print(f"  {name}")
+    
+    # Generate and save sample images using both generators for comparison
+    for i, seed in enumerate(seeds):
+        if i >= num_samples:
+            break
+            
+        # Create a random latent vector
+        z = torch.from_numpy(np.random.RandomState(seed).randn(1, G_original.z_dim)).to(device)
+        
+        # Create a label tensor (zeros for unconditional models)
+        c = torch.zeros([1, G_original.c_dim], device=device)
+        
+        # Generate images with both generators
+        print(f"Generating images for seed {seed}...")
+        
+        # Original generator
+        img_original = G_original(z, c, truncation_psi=0.7, noise_mode='const')
+        img_original = (img_original.permute(0, 2, 3, 1) * 127.5 + 128).clamp(0, 255).to(torch.uint8)
+        
+        # Capped generator
+        img_capped = G_capped(z, c, truncation_psi=0.7, noise_mode='const')
+        img_capped = (img_capped.permute(0, 2, 3, 1) * 127.5 + 128).clamp(0, 255).to(torch.uint8)
+        
+        # Save images
+        PIL.Image.fromarray(img_original[0].cpu().numpy(), 'RGB').save(
+            f"{output_dir}/seed{seed:04d}_original_{G_original.img_resolution}.png")
+        PIL.Image.fromarray(img_capped[0].cpu().numpy(), 'RGB').save(
+            f"{output_dir}/seed{seed:04d}_capped_{target_resolution}.png")
+    
+    print(f"Generated {min(num_samples, len(seeds))} sample images in {output_dir}")
+    
+    # Save the capped generator
+    output_pkl = f"stylegan2_capped_{target_resolution}.pkl"
+    print(f"Saving capped generator to {output_pkl}...")
+    
+    # Create a new network data dictionary with the capped generator
+    capped_network_data = {k: v for k, v in network_data.items()}
+    capped_network_data['G_ema'] = G_capped
+    
+    with open(output_pkl, 'wb') as f:
+        torch.save(capped_network_data, f)
+    
+    print(f"Capped generator saved to {output_pkl}")
+
+if __name__ == "__main__":
+    main()

--- a/stylegan2_resolution_capper.py
+++ b/stylegan2_resolution_capper.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""
+A more detailed implementation for capping the resolution of a StyleGAN2 generator
+from the StyleGAN3 repository.
+"""
+
+import os
+import re
+import copy
+import torch
+import numpy as np
+import PIL.Image
+import dnnlib
+import legacy
+from torch_utils import misc
+
+def inspect_generator(G):
+    """Print detailed information about a generator to help with debugging."""
+    print(f"Generator type: {type(G).__name__}")
+    print(f"Generator resolution: {G.img_resolution}")
+    print(f"Generator z_dim: {G.z_dim}")
+    print(f"Generator c_dim: {G.c_dim}")
+    
+    if hasattr(G, 'synthesis'):
+        print("\nSynthesis network attributes:")
+        for attr_name in dir(G.synthesis):
+            if not attr_name.startswith('_') and not callable(getattr(G.synthesis, attr_name)):
+                attr_value = getattr(G.synthesis, attr_name)
+                print(f"  {attr_name}: {attr_value}")
+        
+        print("\nSynthesis network blocks:")
+        for block_name in dir(G.synthesis):
+            if block_name.startswith('b') and block_name[1:].isdigit():
+                block = getattr(G.synthesis, block_name)
+                print(f"  {block_name}: {type(block).__name__}")
+                
+                # Print block attributes
+                for attr_name in dir(block):
+                    if not attr_name.startswith('_') and not callable(getattr(block, attr_name)):
+                        try:
+                            attr_value = getattr(block, attr_name)
+                            if not isinstance(attr_value, torch.nn.Module):
+                                print(f"    {attr_name}: {attr_value}")
+                        except:
+                            pass
+
+def create_capped_stylegan2_generator(G_original, target_resolution):
+    """
+    Create a new StyleGAN2 generator with a capped resolution based on the original generator.
+    This works specifically with the StyleGAN2 implementation from the StyleGAN3 repository.
+    
+    Args:
+        G_original: The original StyleGAN2 generator model
+        target_resolution: The target resolution to cap at (e.g., 512)
+        
+    Returns:
+        A new generator with the same weights as the original but capped at the target resolution
+    """
+    # Ensure target resolution is a power of 2
+    assert (target_resolution & (target_resolution - 1) == 0) and target_resolution > 0, \
+        f"Target resolution must be a power of 2, got {target_resolution}"
+    
+    # Ensure target resolution is not larger than the original
+    assert target_resolution <= G_original.img_resolution, \
+        f"Target resolution ({target_resolution}) cannot be larger than original ({G_original.img_resolution})"
+    
+    # Create a new generator with the same architecture but different resolution
+    # First, get the original kwargs
+    synthesis_kwargs = copy.deepcopy(G_original.synthesis.init_kwargs)
+    mapping_kwargs = copy.deepcopy(G_original.mapping.init_kwargs)
+    
+    # Update the resolution in the synthesis kwargs
+    synthesis_kwargs['img_resolution'] = target_resolution
+    
+    # Get the original block resolutions
+    orig_block_resolutions = G_original.synthesis.block_resolutions
+    
+    # Filter block resolutions to only include those up to the target resolution
+    new_block_resolutions = [res for res in orig_block_resolutions if res <= target_resolution]
+    synthesis_kwargs['block_resolutions'] = new_block_resolutions
+    
+    # Adjust the number of layers in the mapping network if needed
+    if 'num_layers' in mapping_kwargs:
+        # Keep the mapping network the same size
+        pass
+    
+    # Create a new generator with the updated kwargs
+    from training.networks_stylegan2 import Generator
+    G_capped = Generator(
+        z_dim=G_original.z_dim,
+        c_dim=G_original.c_dim,
+        w_dim=G_original.w_dim,
+        img_resolution=target_resolution,
+        img_channels=G_original.img_channels,
+        mapping_kwargs=mapping_kwargs,
+        synthesis_kwargs=synthesis_kwargs
+    ).eval().requires_grad_(False)
+    
+    # Copy the mapping network weights (these are independent of resolution)
+    misc.copy_params_and_buffers(G_original.mapping, G_capped.mapping, require_all=True)
+    
+    # Copy the synthesis network weights up to the target resolution
+    # For each block in the capped generator, copy the corresponding weights from the original
+    for res in new_block_resolutions:
+        block_name = f'b{res}'
+        if hasattr(G_original.synthesis, block_name) and hasattr(G_capped.synthesis, block_name):
+            orig_block = getattr(G_original.synthesis, block_name)
+            capped_block = getattr(G_capped.synthesis, block_name)
+            
+            # Copy all parameters and buffers for this block
+            misc.copy_params_and_buffers(orig_block, capped_block, require_all=True)
+    
+    # Copy the ToRGB layer for the highest resolution
+    highest_res_block = f'b{new_block_resolutions[-1]}'
+    if hasattr(G_original.synthesis, highest_res_block) and hasattr(G_capped.synthesis, highest_res_block):
+        orig_block = getattr(G_original.synthesis, highest_res_block)
+        capped_block = getattr(G_capped.synthesis, highest_res_block)
+        
+        if hasattr(orig_block, 'torgb') and hasattr(capped_block, 'torgb'):
+            misc.copy_params_and_buffers(orig_block.torgb, capped_block.torgb, require_all=True)
+    
+    return G_capped
+
+def main():
+    """Example usage of the capped generator function."""
+    import argparse
+    
+    parser = argparse.ArgumentParser(description="Create a StyleGAN2 generator with capped resolution")
+    parser.add_argument("--network", type=str, required=True, help="Path to the .pkl file containing the StyleGAN2 model")
+    parser.add_argument("--resolution", type=int, default=512, help="Target resolution to cap at (default: 512)")
+    parser.add_argument("--output", type=str, default="capped_stylegan2.pkl", help="Output .pkl file path")
+    parser.add_argument("--seed", type=int, default=0, help="Random seed for image generation")
+    parser.add_argument("--outdir", type=str, default="out", help="Directory to save output images")
+    parser.add_argument("--inspect", action="store_true", help="Inspect the generator structure")
+    args = parser.parse_args()
+    
+    # Set device
+    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+    print(f"Using device: {device}")
+    
+    # Load the network
+    print(f"Loading network from {args.network}...")
+    with dnnlib.util.open_url(args.network) as f:
+        network_data = legacy.load_network_pkl(f)
+        G_original = network_data['G_ema'].to(device)
+    
+    print(f"Original generator resolution: {G_original.img_resolution}")
+    
+    # Inspect the generator if requested
+    if args.inspect:
+        print("\nInspecting original generator:")
+        inspect_generator(G_original)
+    
+    # Create a capped generator
+    print(f"\nCreating capped generator with resolution {args.resolution}...")
+    G_capped = create_capped_stylegan2_generator(G_original, args.resolution)
+    
+    print(f"Capped generator resolution: {G_capped.img_resolution}")
+    
+    # Inspect the capped generator if requested
+    if args.inspect:
+        print("\nInspecting capped generator:")
+        inspect_generator(G_capped)
+    
+    # Generate a sample image with both generators
+    os.makedirs(args.outdir, exist_ok=True)
+    
+    # Create a random latent vector
+    z = torch.from_numpy(np.random.RandomState(args.seed).randn(1, G_original.z_dim)).to(device)
+    
+    # Create a label tensor (zeros for unconditional models)
+    c = torch.zeros([1, G_original.c_dim], device=device)
+    
+    # Generate images
+    print("Generating images...")
+    
+    # Original generator
+    img_original = G_original(z, c, truncation_psi=0.7, noise_mode='const')
+    img_original = (img_original.permute(0, 2, 3, 1) * 127.5 + 128).clamp(0, 255).to(torch.uint8)
+    
+    # Capped generator
+    img_capped = G_capped(z, c, truncation_psi=0.7, noise_mode='const')
+    img_capped = (img_capped.permute(0, 2, 3, 1) * 127.5 + 128).clamp(0, 255).to(torch.uint8)
+    
+    # Save images
+    PIL.Image.fromarray(img_original[0].cpu().numpy(), 'RGB').save(f"{args.outdir}/original_{G_original.img_resolution}.png")
+    PIL.Image.fromarray(img_capped[0].cpu().numpy(), 'RGB').save(f"{args.outdir}/capped_{args.resolution}.png")
+    
+    print(f"Images saved to {args.outdir}")
+    
+    # Save the capped generator
+    print(f"Saving capped generator to {args.output}...")
+    capped_network_data = {k: v for k, v in network_data.items()}
+    capped_network_data['G_ema'] = G_capped
+    
+    with open(args.output, 'wb') as f:
+        torch.save(capped_network_data, f)
+    
+    print(f"Capped generator saved to {args.output}")
+
+if __name__ == "__main__":
+    main()

--- a/torch_utils/ops/grid_sample_gradfix.py
+++ b/torch_utils/ops/grid_sample_gradfix.py
@@ -22,6 +22,7 @@ from pkg_resources import parse_version
 
 enabled = False  # Enable the custom op by setting this to true.
 _use_pytorch_1_11_api = parse_version(torch.__version__) >= parse_version('1.11.0a') # Allow prerelease builds of 1.11
+_use_pytorch_1_12_api = parse_version(torch.__version__) >= parse_version('1.12.0a') # Allow prerelease builds of 1.12
 
 #----------------------------------------------------------------------------
 
@@ -58,6 +59,8 @@ class _GridSample2dBackward(torch.autograd.Function):
     @staticmethod
     def forward(ctx, grad_output, input, grid):
         op = torch._C._jit_get_operation('aten::grid_sampler_2d_backward')
+        if _use_pytorch_1_12_api:
+            op = op[0]
         if _use_pytorch_1_11_api:
             output_mask = (ctx.needs_input_grad[1], ctx.needs_input_grad[2])
             grad_input, grad_grid = op(grad_output, input, grid, 0, 0, False, output_mask)


### PR DESCRIPTION
This PR adds utilities for capping the resolution of pre-trained StyleGAN2 and StyleGAN3 models. It includes:

- A comprehensive utility module (`cap_resolution_utils.py`) with functions for both StyleGAN2 and StyleGAN3
- A Jupyter notebook demo (`resolution_capping_demo.ipynb`) showing how to use these utilities
- Additional scripts for StyleGAN2 resolution capping

These utilities allow users to load pre-trained models and create generators with capped resolutions (e.g., maximum 512px) to reduce memory usage and computation time while preserving model quality.